### PR TITLE
Fix read-only wrap import error

### DIFF
--- a/src/Primary.jsx
+++ b/src/Primary.jsx
@@ -1,0 +1,45 @@
+// import ReadOnlyWrap from 'desktop-kit/components/read-only-wrap';
+import React, { useEffect } from 'react'
+import { Form, Input, Select, Button, Switch } from 'antd';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import '@ant-design/v5-patch-for-react-19'
+// import ReadOnlyWrap from 'desktop-kit/components/read-only-wrap';
+
+function Primary() {
+  const [form] = Form.useForm();
+  const [show, setShow] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
+  const isBrowser = useIsBrowser();
+  return <BrowserOnly>
+    {
+      () => {
+        const ReadOnlyWrapModule = require('desktop-kit/components/read-only-wrap');
+        // Handle both default and named exports
+        const ReadOnlyWrap = ReadOnlyWrapModule.default || ReadOnlyWrapModule;
+        console.log('ReadOnlyWrap :>> ', ReadOnlyWrap);
+        return <ReadOnlyWrap>
+          <Form form={form}>
+            <Form.Item label="姓名" name="name">
+              <Input placeholder="请输入姓名" />
+            </Form.Item>
+            <Form.Item label="年龄" name="age">
+              <Input placeholder="请输入年龄" />
+            </Form.Item>
+            <Form.Item label="开关" name="switch">
+              <Select options={[{ label: '开', value: '1' }, { label: '关', value: '0' }]} />
+            </Form.Item>
+            <Form.Item label="切换">
+              <Switch checked={visible} onChange={(v) => setVisible(v)} />
+            </Form.Item>
+            <Form.Item>
+              <Button type="primary">提交</Button>
+            </Form.Item>
+          </Form>
+        </ReadOnlyWrap>
+      }
+    }
+  </BrowserOnly>
+}
+
+export default Primary


### PR DESCRIPTION
Correctly extract `ReadOnlyWrap` component from `require()` module to fix 'Element type is invalid' error.

The `require()` call inside `BrowserOnly` returns the entire module object, not just the component. This PR adds logic to check for both `module.default` (for default exports) and the module itself (for named exports) to correctly resolve the `ReadOnlyWrap` component, resolving the "Element type is invalid" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c00493cf-9aa4-4d69-94d7-b78ba9f16f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c00493cf-9aa4-4d69-94d7-b78ba9f16f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

