### PR TITLE
Investigate docusaurus rspack plugin error

### DIFF
--- a/docusaurus-rspack-plugin-typescript.ts
+++ b/docusaurus-rspack-plugin-typescript.ts
@@ -1,0 +1,28 @@
+// 修复版本3: TypeScript版本
+import path from 'path';
+import type { Configuration } from 'webpack';
+
+interface PluginOptions {
+  // 可以在这里定义插件选项的类型
+}
+
+export default function rspackPlugin(options: PluginOptions = {}) {
+  return {
+    name: 'custom-rspack-plugin',
+    configureWebpack(config: Configuration, isServer: boolean) {
+      console.log('isServer :>> ', isServer, 'process.env.NODE_ENV', process.env.NODE_ENV, 'rspack');
+      
+      // 打印输出目录
+      console.log('output before :>> ', config.output);
+      
+      // 安全地修改配置
+      if (config.output && !config.output.path) {
+        config.output.path = path.resolve(process.cwd(), 'dist');
+      }
+      
+      console.log('output after :>> ', config.output);
+
+      return config;
+    },
+  };
+}

--- a/docusaurus-rspack-plugin.js
+++ b/docusaurus-rspack-plugin.js
@@ -1,0 +1,24 @@
+// 修复版本1: 使用CommonJS语法
+const path = require('path');
+const { rspack } = require('@rspack/core');
+
+module.exports = function rspackPlugin() {
+  return {
+    name: 'custom-rspack-plugin',
+    configureWebpack(config, isServer) {
+      console.log('isServer :>> ', isServer, 'process.env.NODE_ENV', process.env.NODE_ENV, 'rspack');
+      
+      // 打印输出目录
+      console.log('output before :>> ', config.output);
+      
+      // 如果需要修改输出路径，确保路径正确
+      if (config.output && !config.output.path) {
+        config.output.path = path.resolve(process.cwd(), 'dist');
+      }
+      
+      console.log('output after :>> ', config.output);
+
+      return config;
+    },
+  };
+};

--- a/docusaurus-rspack-plugin.mjs
+++ b/docusaurus-rspack-plugin.mjs
@@ -1,0 +1,29 @@
+// 修复版本2: 使用ES Module语法
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { rspack } from '@rspack/core';
+
+// 在ES Module中获取__dirname的等价物
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default function rspackPlugin() {
+  return {
+    name: 'custom-rspack-plugin',
+    configureWebpack(config, isServer) {
+      console.log('isServer :>> ', isServer, 'process.env.NODE_ENV', process.env.NODE_ENV, 'rspack');
+      
+      // 打印输出目录
+      console.log('output before :>> ', config.output);
+      
+      // 如果需要修改输出路径，使用正确的ES Module路径解析
+      if (config.output && !config.output.path) {
+        config.output.path = path.resolve(process.cwd(), 'dist');
+      }
+      
+      console.log('output after :>> ', config.output);
+
+      return config;
+    },
+  };
+}


### PR DESCRIPTION
Add three versions (CommonJS, ES Module, TypeScript) of a Docusaurus custom plugin to fix errors related to mixed module syntax and incorrect path resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-da784358-9eff-44c4-b0f7-992680b05eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da784358-9eff-44c4-b0f7-992680b05eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

