### PR TITLE
Resolve typescript module import errors

### DIFF
--- a/src/TestClipboardComponent.tsx
+++ b/src/TestClipboardComponent.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+// This import should now work without the file extension
+import ClipboardText from 'desktop-kit/components/clipboard-text/index';
+
+const TestClipboardComponent: React.FC = () => {
+  return (
+    <div>
+      <h2>Test Clipboard Component</h2>
+      <ClipboardText 
+        text="Hello, World!" 
+        onCopy={() => console.log('Text copied!')} 
+      />
+    </div>
+  );
+};
+
+export default TestClipboardComponent;

--- a/src/desktop-kit/components/clipboard-text/index.ts
+++ b/src/desktop-kit/components/clipboard-text/index.ts
@@ -1,0 +1,2 @@
+export { default } from './index';
+export type { ClipboardTextProps } from './index';

--- a/src/desktop-kit/components/clipboard-text/index.tsx
+++ b/src/desktop-kit/components/clipboard-text/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export interface ClipboardTextProps {
+  text: string;
+  onCopy?: () => void;
+}
+
+const ClipboardText: React.FC<ClipboardTextProps> = ({ text, onCopy }) => {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      onCopy?.();
+    } catch (error) {
+      console.error('Failed to copy text:', error);
+    }
+  };
+
+  return (
+    <div className="clipboard-text">
+      <span>{text}</span>
+      <button onClick={handleCopy}>Copy</button>
+    </div>
+  );
+};
+
+export default ClipboardText;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "desktop-kit/*": ["node_modules/desktop-kit/*", "src/desktop-kit/*"]
+    }
   },
   "include": [
     "src",


### PR DESCRIPTION
Update `tsconfig.json` to enable module imports without file extensions, resolving TypeScript resolution errors.

The user encountered a TypeScript error (`TS2307`) when attempting to import `desktop-kit/components/clipboard-text/index` without specifying the file extension. This PR configures `tsconfig.json` with `baseUrl` and `paths` to allow TypeScript to correctly resolve such imports, demonstrating the fix with a mock `desktop-kit` module structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed0a530e-3388-4395-8133-d7549b959ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed0a530e-3388-4395-8133-d7549b959ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

