### PR TITLE
Resolve typescript module import errors

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,14 @@
+const path = require('path');
+
+module.exports = function override(config) {
+  // Add support for importing without extensions
+  config.resolve.extensions = ['.ts', '.tsx', '.js', '.jsx', '.json', ...config.resolve.extensions];
+  
+  // Ensure module resolution works for desktop-kit
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    'desktop-kit': path.resolve(__dirname, 'desktop-kit'),
+  };
+
+  return config;
+};

--- a/desktop-kit/components/clipboard-text/index.tsx
+++ b/desktop-kit/components/clipboard-text/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface ClipboardTextProps {
+  text: string;
+  onCopy?: () => void;
+}
+
+const ClipboardText: React.FC<ClipboardTextProps> = ({ text, onCopy }) => {
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    onCopy?.();
+  };
+
+  return (
+    <div>
+      <span>{text}</span>
+      <button onClick={handleCopy}>Copy</button>
+    </div>
+  );
+};
+
+export default ClipboardText;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "moment": "^2.29.4"
+        "moment": "^2.29.4",
+        "react-app-rewired": "^2.2.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13809,6 +13810,32 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-app-rewired": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.2.1.tgz",
+      "integrity": "sha512-uFQWTErXeLDrMzOJHKp0h8P1z0LV9HzPGsJ6adOtGlA/B9WfT6Shh4j2tLTTGlXOfiVx6w6iWpp7SOC5pvk+gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.6.0"
+      },
+      "bin": {
+        "react-app-rewired": "bin/index.js"
+      },
+      "peerDependencies": {
+        "react-scripts": ">=2.1.3"
+      }
+    },
+    "node_modules/react-app-rewired/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -26467,6 +26494,23 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
+      }
+    },
+    "react-app-rewired": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.2.1.tgz",
+      "integrity": "sha512-uFQWTErXeLDrMzOJHKp0h8P1z0LV9HzPGsJ6adOtGlA/B9WfT6Shh4j2tLTTGlXOfiVx6w6iWpp7SOC5pvk+gA==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
+        }
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -42,6 +42,7 @@
     ]
   },
   "devDependencies": {
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "react-app-rewired": "^2.2.1"
   }
 }

--- a/src/TestImport.tsx
+++ b/src/TestImport.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+// This import should work without the .tsx extension
+import ClipboardText from 'desktop-kit/components/clipboard-text/index';
+
+const TestImport: React.FC = () => {
+  return (
+    <div>
+      <h1>Testing Import Without Extension</h1>
+      <ClipboardText text="Hello, World!" onCopy={() => console.log('Copied!')} />
+    </div>
+  );
+};
+
+export default TestImport;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,10 +18,15 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "desktop-kit/*": ["desktop-kit/*"]
+    }
   },
   "include": [
     "src",
-    "src/@types"
+    "src/@types",
+    "desktop-kit"
   ]
 }


### PR DESCRIPTION
Enable importing `desktop-kit` modules without file extensions by configuring TypeScript and Webpack.

This solution addresses module resolution issues in a Create React App environment by updating `tsconfig.json` for path mapping and utilizing `react-app-rewired` to customize Webpack's module resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-df8c520b-7db5-48c1-9a30-a0a0d15b1e0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df8c520b-7db5-48c1-9a30-a0a0d15b1e0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

